### PR TITLE
Improve build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,25 +10,21 @@ NOT FINISHED YET.
 ## Requirements
 
 - Node.JS (at least v16)
-- Neutralino.JS : `npm install -g @neutralinojs/neu`
+- webkit2gtk4.0
 
 ## How to compile
 
 ```sh
 git clone https://github.com/steevelefort/hhg-gui.git
 cd hhg-gui
-neu update
-cd hhkb-react
-npm install
-npm run build
-cd ..
-neu build --release
+chmod +x build.sh
+./build.sh
 ```
 Builds are now in the dist folder.
 
 Builds were successfully made on 
 
-- **Fedora** (36) 
+- **Fedora** (39) 
 - **OpenSuse Tumbleweed**.
 
 ## Usage

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+npx neu update
+cd hhkb-react || { echo "Failed to change directory to hhkb-react"; exit 1; }
+npm install
+npm run build
+cd ..
+npx neu build --release


### PR DESCRIPTION
This PR improves the documentation and build steps in order to make it easier for users to successfully build the application. Now `webkit2gtk4.0` is identified as a dependency, and Neutralino.JS is no longer required to be installed by using `npx`.

I also confirmed that this application builds on Fedora 39.